### PR TITLE
Add the BoundedCache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,4 +1,129 @@
-package cache
+package boundedcache
 
-type RateLimitCache struct {
+import (
+	"errors"
+	"sync"
+)
+
+type BoundedCache struct {
+	staleItems    map[interface{}]interface{}
+	freshItems    map[interface{}]interface{}
+	maxItemMapLen int
+
+	rwm sync.RWMutex
+}
+
+func New(maxItems int) (*BoundedCache, error) {
+	if maxItems < 2 {
+		return nil, errors.New("maxItems must be at least 2")
+	}
+
+	return &BoundedCache{
+		staleItems:    make(map[interface{}]interface{}),
+		freshItems:    make(map[interface{}]interface{}),
+		maxItemMapLen: maxItems / 2,
+	}, nil
+}
+
+func (b *BoundedCache) MaxItems() int {
+	return b.maxItemMapLen * 2
+}
+
+func (b *BoundedCache) Len() int {
+	b.rwm.RLock()
+	defer b.rwm.RUnlock()
+
+	return len(b.freshItems) + len(b.staleItems)
+}
+
+func (b *BoundedCache) Purge() {
+	b.rwm.Lock()
+	defer b.rwm.Unlock()
+
+	b.staleItems = make(map[interface{}]interface{})
+	b.freshItems = make(map[interface{}]interface{})
+}
+
+func (b *BoundedCache) Add(key, val interface{}) (evicted bool) {
+	b.rwm.Lock()
+	defer b.rwm.Unlock()
+
+	return b.addLocked(key, val)
+}
+
+// Get looks in the cache for the given key, returning its value.
+// This cache can potentially evict items during a Get request, if the value
+// is in the stale half of the cache and the fresh half is full.
+func (b *BoundedCache) Get(key interface{}) (val interface{}, ok bool, evicted bool) {
+	// multiple readers can get items concurrently
+	b.rwm.RLock()
+	if val, ok = b.freshItems[key]; ok {
+		b.rwm.RUnlock()
+		return val, ok, evicted
+	}
+	b.rwm.RUnlock()
+
+	// enter the write-protected zone
+	b.rwm.Lock()
+	defer b.rwm.Unlock()
+
+	// see if the item is in priorItems. If so, move to the currentItems map
+	// so that it remains in the "fresh" half of the cache
+	if val, ok = b.staleItems[key]; ok {
+		delete(b.staleItems, key)
+		evicted = b.addLocked(key, val)
+		return val, ok, evicted
+	}
+
+	return nil, false, false
+}
+
+func (b *BoundedCache) GetOrCreate(key interface{}, create func() interface{}) (val interface{}, created bool, evicted bool) {
+	// multiple readers can get items concurrently
+	var ok bool
+	b.rwm.RLock()
+
+	if val, ok = b.freshItems[key]; ok {
+		b.rwm.RUnlock()
+		return val, created, evicted
+	}
+	b.rwm.RUnlock()
+
+	// enter the write-protected zone
+	b.rwm.Lock()
+	defer b.rwm.Unlock()
+
+	// see if the item is in priorItems. If so, move to the currentItems map
+	// so that it remains in the "fresh" half of the cache
+	if val, ok = b.staleItems[key]; ok {
+		delete(b.staleItems, key)
+		evicted = b.addLocked(key, val)
+		return val, created, evicted
+	}
+
+	// ensure that this value wasn't added by another concurrent goroutine
+	if val, ok = b.freshItems[key]; ok {
+		return val, created, evicted
+	}
+
+	// if here, a value needs to be created.
+	created = true
+	val = create()
+	evicted = b.addLocked(key, val)
+
+	return val, created, evicted
+}
+
+// addLocked adds val to the cache while the cache is already locked
+// It checks if the currentItem map is full, and if so, shifts the
+// currentItem map to priorItem, and generates a new map.
+func (b *BoundedCache) addLocked(key, val interface{}) (evicted bool) {
+	if len(b.freshItems) >= b.maxItemMapLen {
+		b.staleItems = b.freshItems
+		b.freshItems = make(map[interface{}]interface{})
+		evicted = true
+	}
+
+	b.freshItems[key] = val
+	return evicted
 }

--- a/cache.go
+++ b/cache.go
@@ -5,46 +5,46 @@ import (
 	"sync"
 )
 
-type BoundedCache struct {
-	staleItems    map[interface{}]interface{}
-	freshItems    map[interface{}]interface{}
+type BoundedCache[V any] struct {
+	staleItems    map[string]V
+	freshItems    map[string]V
 	maxItemMapLen int
 
 	rwm sync.RWMutex
 }
 
-func New(maxItems int) (*BoundedCache, error) {
-	if maxItems < 2 {
-		return nil, errors.New("maxItems must be at least 2")
+func NewBoundedCache[V any](maxItems int) (*BoundedCache[V], error) {
+	if maxItems < 1 {
+		return nil, errors.New("maxItems must be at least 1")
 	}
 
-	return &BoundedCache{
-		staleItems:    make(map[interface{}]interface{}),
-		freshItems:    make(map[interface{}]interface{}),
-		maxItemMapLen: maxItems / 2,
+	return &BoundedCache[V]{
+		staleItems:    make(map[string]V),
+		freshItems:    make(map[string]V),
+		maxItemMapLen: (maxItems + 1) / 2,
 	}, nil
 }
 
-func (b *BoundedCache) MaxItems() int {
+func (b *BoundedCache[V]) MaxItems() int {
 	return b.maxItemMapLen * 2
 }
 
-func (b *BoundedCache) Len() int {
+func (b *BoundedCache[V]) Len() int {
 	b.rwm.RLock()
 	defer b.rwm.RUnlock()
 
 	return len(b.freshItems) + len(b.staleItems)
 }
 
-func (b *BoundedCache) Purge() {
+func (b *BoundedCache[V]) Purge() {
 	b.rwm.Lock()
 	defer b.rwm.Unlock()
 
-	b.staleItems = make(map[interface{}]interface{})
-	b.freshItems = make(map[interface{}]interface{})
+	b.staleItems = make(map[string]V)
+	b.freshItems = make(map[string]V)
 }
 
-func (b *BoundedCache) Add(key, val interface{}) (evicted bool) {
+func (b *BoundedCache[V]) Add(key string, val V) (evicted bool) {
 	b.rwm.Lock()
 	defer b.rwm.Unlock()
 
@@ -54,7 +54,7 @@ func (b *BoundedCache) Add(key, val interface{}) (evicted bool) {
 // Get looks in the cache for the given key, returning its value.
 // This cache can potentially evict items during a Get request, if the value
 // is in the stale half of the cache and the fresh half is full.
-func (b *BoundedCache) Get(key interface{}) (val interface{}, ok bool, evicted bool) {
+func (b *BoundedCache[V]) Get(key string) (val V, ok bool, evicted bool) {
 	// multiple readers can get items concurrently
 	b.rwm.RLock()
 	if val, ok = b.freshItems[key]; ok {
@@ -75,15 +75,36 @@ func (b *BoundedCache) Get(key interface{}) (val interface{}, ok bool, evicted b
 		return val, ok, evicted
 	}
 
-	return nil, false, false
+	var nilV V
+	return nilV, false, false
 }
 
-func (b *BoundedCache) GetOrCreate(key interface{}, create func() interface{}) (val interface{}, created bool, evicted bool) {
+// Peek looks in the cache for the given key, returning its value.
+// This operation does not update the underlying cache. It does however
+// indicate whether the cached item is "stale", meaning it is subject
+// to eviction if the fresh half of the cache becomes full.
+func (b *BoundedCache[V]) Peek(key string) (val V, ok bool, stale bool) {
 	// multiple readers can get items concurrently
-	var ok bool
 	b.rwm.RLock()
+	defer b.rwm.RUnlock()
 
 	if val, ok = b.freshItems[key]; ok {
+		return val, true, false
+	}
+
+	if val, ok = b.staleItems[key]; ok {
+		return val, true, true
+	}
+
+	var nilV V
+	return nilV, false, false
+}
+
+func (b *BoundedCache[V]) GetOrCreate(key string, create func() V) (_ V, created bool, evicted bool) {
+	// multiple readers can get items concurrently
+	b.rwm.RLock()
+
+	if val, ok := b.freshItems[key]; ok {
 		b.rwm.RUnlock()
 		return val, created, evicted
 	}
@@ -95,20 +116,20 @@ func (b *BoundedCache) GetOrCreate(key interface{}, create func() interface{}) (
 
 	// see if the item is in priorItems. If so, move to the currentItems map
 	// so that it remains in the "fresh" half of the cache
-	if val, ok = b.staleItems[key]; ok {
+	if val, ok := b.staleItems[key]; ok {
 		delete(b.staleItems, key)
 		evicted = b.addLocked(key, val)
 		return val, created, evicted
 	}
 
 	// ensure that this value wasn't added by another concurrent goroutine
-	if val, ok = b.freshItems[key]; ok {
+	if val, ok := b.freshItems[key]; ok {
 		return val, created, evicted
 	}
 
 	// if here, a value needs to be created.
 	created = true
-	val = create()
+	val := create()
 	evicted = b.addLocked(key, val)
 
 	return val, created, evicted
@@ -117,11 +138,11 @@ func (b *BoundedCache) GetOrCreate(key interface{}, create func() interface{}) (
 // addLocked adds val to the cache while the cache is already locked
 // It checks if the currentItem map is full, and if so, shifts the
 // currentItem map to priorItem, and generates a new map.
-func (b *BoundedCache) addLocked(key, val interface{}) (evicted bool) {
+func (b *BoundedCache[V]) addLocked(key string, val V) (evicted bool) {
 	if len(b.freshItems) >= b.maxItemMapLen {
+		evicted = len(b.staleItems) > 0
 		b.staleItems = b.freshItems
-		b.freshItems = make(map[interface{}]interface{})
-		evicted = true
+		b.freshItems = make(map[string]V)
 	}
 
 	b.freshItems[key] = val

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,1 +1,196 @@
-package cache
+package boundedcache
+
+import (
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewBoundedCache(t *testing.T) {
+	if b, err := NewBoundedCache[int](-1); err == nil || b != nil {
+		t.Fatalf("expect negative size cache to produce an error")
+	}
+
+	if b, err := NewBoundedCache[int](0); err == nil || b != nil {
+		t.Fatalf("expect cache with size less than 1 to produce an error")
+	}
+
+	if b, err := NewBoundedCache[int](1); err != nil || b == nil || b.MaxItems() != 2 {
+		t.Fatalf("expect cache with size 1 to be valid but round up to 2")
+	}
+
+	if b, err := NewBoundedCache[int](100); err != nil || b == nil || b.MaxItems() != 100 {
+		t.Fatalf("expect cache with size 100 to be valid")
+	}
+}
+
+func TestBoundedCacheBehavior(t *testing.T) {
+	// create a cache with 100 items, in order, with key "0" through "99"
+	b, err := NewBoundedCache[int](100)
+	if err != nil || b == nil {
+		t.Fatalf("expected cache creation to be successful")
+	}
+
+	for i := 0; i < 100; i++ {
+		if evicted := b.Add(strconv.Itoa(i), i); evicted == true {
+			t.Fatalf("no evictions expected as cache is populated")
+		}
+	}
+
+	// peek into all the items
+	for i := 0; i < 100; i++ {
+		val, ok, stale := b.Peek(strconv.Itoa(i))
+		if !ok || val != i {
+			t.Fatalf("unexpected missing item from cache, %d is not present", i)
+		}
+
+		expectStale := i < 50
+		if stale != expectStale {
+			t.Fatalf("unexpected staleness in cache, value = %d, expected %v, got %v", i, expectStale, stale)
+		}
+	}
+
+	// any items in the "fresh" half of the cache should be present, and not cause an eviction
+	for i := 50; i < 100; i++ {
+		val, ok, evicted := b.Get(strconv.Itoa(i))
+		if evicted {
+			t.Fatalf("no evictions expected in fresh half of cache")
+		}
+		if !ok || val != i {
+			t.Fatalf("unexpected absent item in fresh half of cache")
+		}
+	}
+
+	// get "25" from the cache. The expected behavior is that an eviction occurs, dropping items "1" - "49",
+	// and moving "50" through "99" to the stale half of the cache.
+	if val, ok, evicted := b.Get("25"); !ok || val != 25 {
+		t.Fatalf("missing value 25 from the cache")
+	} else if !evicted {
+		t.Fatalf("expected a stale Get to evict items from cache")
+	}
+
+	// peek again this time "0" through "49" should all be missing (except for "25").
+	// "50" - "99" are all stale, and "25" is the only fresh item
+	for i := 0; i < 100; i++ {
+		val, ok, stale := b.Peek(strconv.Itoa(i))
+		expectOk := i >= 50 || i == 25
+		expectStale := i >= 50
+
+		if expectOk {
+			if !ok || val != i {
+				t.Fatalf("unexpected missing item from cache, %d is not present", i)
+			}
+			if stale != expectStale {
+				t.Fatalf("unexpected staleness in cache, value = %d, expected %v, got %v", i, expectStale, stale)
+			}
+		} else {
+			if ok {
+				t.Fatalf("unexpected present item in cache, %d is present", i)
+			}
+		}
+	}
+}
+
+func Benchmark_BoundedCacheWithHeadroom(b *testing.B) {
+	keyCounts := make(map[string]int)
+	for i := 0; i < 256; i++ {
+		keyCounts[strconv.Itoa(i)] = 1
+	}
+
+	benchmarkBoundedCache(b, 512, keyCounts, createCachedInt)
+}
+
+func Benchmark_BoundedCacheWithEvictions(b *testing.B) {
+	keyCounts := make(map[string]int)
+	for i := 0; i < 256; i++ {
+		keyCounts[strconv.Itoa(i)] = 1
+	}
+
+	benchmarkBoundedCache(b, 128, keyCounts, createCachedInt)
+}
+
+func Benchmark_BoundedCacheWithHotKeys(b *testing.B) {
+	keyCounts := make(map[string]int)
+	for i := 0; i < 256+10; i++ {
+		keyCounts[strconv.Itoa(i)] = 1
+	}
+	keyCounts["hot1"] = 2500
+	keyCounts["hot2"] = 2500
+
+	benchmarkBoundedCache(b, 512, keyCounts, createCachedInt)
+}
+
+func benchmarkBoundedCache(b *testing.B, maxItems int, keyCounts map[string]int, createFn func() int) {
+	b.Helper()
+	cache, err := NewBoundedCache[int](maxItems)
+	if err != nil {
+		b.Fatalf("error creating cache: %v", err)
+	}
+
+	// convert keys into a slice
+	keys := make([]string, 0)
+	for key, count := range keyCounts {
+		for i := 0; i < count; i++ {
+			keys = append(keys, key)
+		}
+	}
+
+	// shuffle the slice
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var mu sync.Mutex
+	var totalHitCount, totalMissCount, totalEvictCount int
+
+	b.RunParallel(func(pb *testing.PB) {
+		var hitCount, missCount, evictCount int
+		var created, evicted bool
+
+		mu.Lock()
+		index := rand.Intn(len(keys))
+		_, created, evicted = cache.GetOrCreate(keys[index], createFn)
+		if created || evicted {
+
+		}
+		mu.Unlock()
+
+		for pb.Next() {
+			if index >= len(keys) {
+				index = 0
+			}
+
+			_, created, evicted = cache.GetOrCreate(keys[index], createFn)
+			if created {
+				missCount++
+			} else {
+				hitCount++
+			}
+			if evicted {
+				evictCount++
+			}
+
+			index++
+		}
+
+		mu.Lock()
+		totalHitCount += hitCount
+		totalMissCount += missCount
+		totalEvictCount += evictCount
+		mu.Unlock()
+	})
+
+	/*
+		b.Logf("Hit: %d miss: %d ratio: %f evictions: %d", totalHitCount, totalMissCount,
+			float64(totalHitCount)/float64(totalMissCount), totalEvictCount)
+
+	*/
+}
+
+func createCachedInt() int {
+	return 0
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ryderlewis/boundedcache
 
-go 1.17
+go 1.18


### PR DESCRIPTION
BoundedCache is a caching type that uses two maps internally, each providing 50% of the total capacity. There is a "fresh" map containing the most recently used items, and a "stale" map containing the least recently used items.

The rough expectation is that the BoundedCache should have enough capacity to hold all of the frequently-used items in the "fresh" half, but if an unexpected burst of values appears, and the cache grows beyond the limits, the "stale" half will be garbage collected.

This cache uses a read lock to retrieve items from the fresh half, and only requires a write lock if new items are added to the cache, or if a stale entry is promoted to a fresh entry. This should help with lock contention under heavy load from hot keys.